### PR TITLE
Update to be phpcs WordPress-Extra compliant

### DIFF
--- a/class-wc-gateway-coinbase.php
+++ b/class-wc-gateway-coinbase.php
@@ -214,7 +214,7 @@ class WC_Gateway_Coinbase extends WC_Payment_Gateway {
 		$metadata = array(
 			'order_id'  => $order->get_id(),
 			'order_key' => $order->get_order_key(),
-            		'source' => 'woocommerce'
+            		'source'    => 'woocommerce'
 		);
 		$result   = Coinbase_API_Handler::create_charge(
 			$order->get_total(), get_woocommerce_currency(), $metadata,


### PR DESCRIPTION
Add in whitespace for source => 'woocommerce' to align with previous lines.